### PR TITLE
Fix CS0618: [PreferenceItem] is obsolete (AutoLOD.cs)

### DIFF
--- a/Editor/AutoLOD.cs
+++ b/Editor/AutoLOD.cs
@@ -683,8 +683,19 @@ namespace Unity.AutoLOD
             }
         }
 
+#if UNITY_2018_3_OR_NEWER
+        [SettingsProvider]
+        static SettingsProvider PreferencesGUI()
+        {
+            return new SettingsProvider("Preferences/AutoLOD", SettingsScope.User)
+            {
+                guiHandler = (searchContext) => DeprecatedPreferencesGUI(),
+            };
+        }
+#else
         [PreferenceItem("AutoLOD")]
-        static void PreferencesGUI()
+#endif
+        static void DeprecatedPreferencesGUI()
         {
             EditorGUILayout.BeginVertical();
             EditorGUILayout.Space();


### PR DESCRIPTION
Fix https://github.com/Unity-Technologies/AutoLOD/issues/91

Thanks for guidance to
https://forum.unity.com/threads/preferenceitem-is-deprecated-use-settingsprovider-instead.678715